### PR TITLE
Add option for different RGB colour order with ST7789

### DIFF
--- a/TFT_Drivers/ST7789_Defines.h
+++ b/TFT_Drivers/ST7789_Defines.h
@@ -45,6 +45,20 @@
 #define TFT_MAD_SS  0x02
 #define TFT_MAD_GS  0x01
 
+#ifdef TFT_RGB_ORDER
+  #if (TFT_RGB_ORDER == 1)
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
+  #else
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+  #endif
+#else
+  #ifdef CGRAM_OFFSET
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_BGR
+  #else
+    #define TFT_MAD_COLOR_ORDER TFT_MAD_RGB
+  #endif
+#endif
+
 #define TFT_IDXRD   0x00 // ILI9341 only, indexed control register read
 
 // ST7789 specific commands used in init

--- a/TFT_Drivers/ST7789_Init.h
+++ b/TFT_Drivers/ST7789_Init.h
@@ -14,12 +14,7 @@
   //------------------------------display and color format setting--------------------------------//
   writecommand(ST7789_MADCTL);
   writedata(0x00);
-#ifdef CGRAM_OFFSET
-  writedata(0x48); // BGR colour order for 240 x 240 TFT
-#else
-  writedata(0x40); // RGB colour order for 240 x 320 TFT (Issue #232)
-#endif
-
+  writedata(TFT_MAD_COLOR_ORDER);
 
   // JLX240 display datasheet
   writecommand(0xB6);

--- a/TFT_Drivers/ST7789_Rotation.h
+++ b/TFT_Drivers/ST7789_Rotation.h
@@ -5,47 +5,43 @@
   switch (rotation) {
     case 0: // Portrait
 #ifdef CGRAM_OFFSET
-      writedata(TFT_MAD_BGR);
       colstart = 0;
       rowstart = 0;
-#else
-      writedata(TFT_MAD_RGB);
 #endif
+      writedata(TFT_MAD_COLOR_ORDER);
+
       _width  = _init_width;
       _height = _init_height;
       break;
 
     case 1: // Landscape (Portrait + 90)
 #ifdef CGRAM_OFFSET
-      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_BGR);
       colstart = 0;
       rowstart = 0;
-#else
-      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_RGB);
 #endif
+      writedata(TFT_MAD_MX | TFT_MAD_MV | TFT_MAD_COLOR_ORDER);
+
       _width  = _init_height;
       _height = _init_width;
       break;
 
       case 2: // Inverter portrait
 #ifdef CGRAM_OFFSET
-       writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_BGR);
        colstart = 0;
        rowstart = 80;
-#else
-      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_RGB);
 #endif
+      writedata(TFT_MAD_MX | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+
       _width  = _init_width;
       _height = _init_height;
        break;
     case 3: // Inverted landscape
 #ifdef CGRAM_OFFSET
-      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_BGR);
       colstart = 80;
       rowstart = 0;
-#else
-      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_RGB);
 #endif
+      writedata(TFT_MAD_MV | TFT_MAD_MY | TFT_MAD_COLOR_ORDER);
+
       _width  = _init_height;
       _height = _init_width;
       break;

--- a/User_Setup.h
+++ b/User_Setup.h
@@ -29,6 +29,10 @@
 // For M5Stack ESP32 module with integrated display ONLY, remove // in line below
 //#define M5STACK
 
+// For ST7789 ONLY, define the colour order IF the blue and red are swapped on your display
+//#define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+//#define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
 // For ST7789, ST7735 and ILI9163 ONLY, define the pixel width and height in portrait orientation
 // #define TFT_WIDTH  80
 // #define TFT_WIDTH  128

--- a/User_Setup_Select.h
+++ b/User_Setup_Select.h
@@ -60,6 +60,11 @@
 /////////////////////////////////////////////////////////////////////////////////////
 
 
+// Identical looking TFT displays may have a different colour ordering in the 16 bit colour
+#define TFT_BGR 0   // Colour order Blue-Green-Red
+#define TFT_RGB 1   // Colour order Red-Green-Blue
+
+
 // Load the right driver definition - do not tinker here !
 #if   defined (ILI9341_DRIVER)
      #include <TFT_Drivers/ILI9341_Defines.h>
@@ -100,6 +105,7 @@
 #else
      #define  TFT_DRIVER 0x0000
 #endif
+
 
 // These are the pins for all ESP8266 boards
 //      Name   GPIO    Function

--- a/User_Setups/SetupX_Template.h
+++ b/User_Setups/SetupX_Template.h
@@ -26,6 +26,11 @@
 //#define ILI9488_DRIVER
 //#define ST7789_DRIVER // Define the screen size below for this display
 
+// For ST7789 ONLY, define the colour order if the blue and red are swapped on your display
+// Try ONE option at a time to find the correct colour order for your display
+//#define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
+//#define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red
+
 // For M5Stack ESP32 module with integrated display ONLY, remove // in line below
 //#define M5STACK
 

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "TFT_eSPI",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": "tft, ePaper, display, ESP8266, NodeMCU, ESP32, M5Stack, ILI9341, ST7735, ILI9163, S6D02A1, ILI9486, ST7789",
   "description": "A TFT and ePaper SPI graphics library for ESP8266 and ESP32",
   "repository":

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TFT_eSPI
-version=1.2.1
+version=1.2.2
 author=Bodmer
 maintainer=Bodmer
 sentence=A fast TFT graphics library for ESP8266 and ESP32 processors for the Arduino IDE


### PR DESCRIPTION
// For ST7789 ONLY, define the colour order IF the blue and red are
swapped on your display
//#define TFT_RGB_ORDER TFT_RGB  // Colour order Red-Green-Blue
//#define TFT_RGB_ORDER TFT_BGR  // Colour order Blue-Green-Red